### PR TITLE
Changed staking bond denomination to fet from stake

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -8,7 +8,7 @@ import (
 const (
 
 	// default bond denomination
-	DefaultBondDenom = "stake"
+	DefaultBondDenom = "fet"
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if


### PR DESCRIPTION
This PR changes the default staking bond denomination from `stake` to `fet`