### PR TITLE
Changed defaultbonddenom to ufet instead of fet

### DIFF
--- a/types/staking.go
+++ b/types/staking.go
@@ -8,7 +8,7 @@ import (
 const (
 
 	// default bond denomination
-	DefaultBondDenom = "fet"
+	DefaultBondDenom = "ufet"
 
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if


### PR DESCRIPTION
This PR changes the default bonddenom from fet to ufet. This is necessary for big-dipper, and 6 decimals points are the default for Gaia.

Merging as it is the exact same changes the PR which changed the bonddenom from stake to fet