### PR TITLE
Remove mature queue items every end block

### DIFF
--- a/types/coin_benchmark_test.go
+++ b/types/coin_benchmark_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -12,10 +13,10 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+strconv.Itoa(i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+strconv.Itoa(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()
@@ -41,10 +42,10 @@ func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(numCoinsB+i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+strconv.Itoa(numCoinsB+i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+strconv.Itoa(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()

--- a/x/staking/keeper/delay_updates.go
+++ b/x/staking/keeper/delay_updates.go
@@ -33,6 +33,9 @@ func (k Keeper) CheckValidatorUpdates(ctx sdk.Context, header abci.Header) {
 func (k Keeper) DKGValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate {
 	store := ctx.KVStore(k.storeKey)
 	if len(store.Get(computeDKGValidatorUpdateKey)) == 0 {
+		// Check mature items in queues every block, regardless of whether return validator updates
+		// or not, in order for items to be removed as soon as possible
+		k.RemoveMatureQueueItems(ctx)
 		return []abci.ValidatorUpdate{}
 	}
 	store.Set(computeDKGValidatorUpdateKey, []byte{})


### PR DESCRIPTION
Check for mature items in validator, unbonding and redelegation queues at every EndBlocker, regardless of whether validator updates are returned. This ensures that these items are removed from the queues as soon as possible. 