### PR TITLE
Add metrics for different validator sets

### DIFF
--- a/docs/core/telemetry.md
+++ b/docs/core/telemetry.md
@@ -102,6 +102,11 @@ The following examples expose too much cardinality and may not even prove to be 
 | `abci_end_block`                | Duration of ABCI `EndBlock`                                                            | ms              | summary |
 | `begin_blocker`                 | Duration of `BeginBlock` for a given module                                            | ms              | summary |
 | `end_blocker`                   | Duration of `EndBlock` for a given module                                              | ms              | summary |
+| `staking_vals_bonded`           | Number of bonded validators                                                            | validators      | gauge   |
+| `staking_vals_jailed`           | Number of jailed validators                                                            | validators      | gauge   |
+| `staking_vals_producing_blocks` | Number of validators producing blocks                                                  | validators      | gauge   |
+| `staking_vals_unbonded`         | Number of unbonded validators                                                          | validators      | gauge   |
+| `staking_vals_unbonding`        | Number of unbonding validators                                                         | validators      | gauge   |
 | `store_iavl_get`                | Duration of an IAVL `Store#Get` call                                                   | ms              | summary |
 | `store_iavl_set`                | Duration of an IAVL `Store#Set` call                                                   | ms              | summary |
 | `store_iavl_has`                | Duration of an IAVL `Store#Has` call                                                   | ms              | summary |

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -260,6 +260,38 @@ func (k Keeper) ValidatorsPowerStoreIterator(ctx sdk.Context) sdk.Iterator {
 	return sdk.KVStoreReversePrefixIterator(store, types.ValidatorsByPowerIndexKey)
 }
 
+// GetValidatorSetMetrics returns number of validators in the states bonded, unbonding, unbonded, producing blocks, and
+// jailed
+func (k Keeper) GetValidatorSetMetrics(ctx sdk.Context) (int64, int64, int64, int64, int64) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.ValidatorsKey)
+	defer iterator.Close()
+
+	numBonded := int64(0)
+	numUnbonding := int64(0)
+	numUnbonded := int64(0)
+	numProducingBlocks := int64(0)
+	numJailed := int64(0)
+	for ; iterator.Valid(); iterator.Next() {
+		validator := types.MustUnmarshalValidator(k.cdc, iterator.Value())
+		if validator.IsBonded() {
+			numBonded++
+		} else if validator.IsUnbonding() {
+			numUnbonding++
+		} else if validator.IsUnbonded() {
+			numUnbonded++
+		}
+
+		if validator.IsProducingBlocks() {
+			numProducingBlocks++
+		}
+		if validator.IsJailed() {
+			numJailed++
+		}
+	}
+	return numBonded, numUnbonding, numUnbonded, numProducingBlocks, numJailed
+}
+
 //_______________________________________________________________________
 // Last Validator Index
 


### PR DESCRIPTION
Add metrics for reporting the number of validators in the states: bonded, unbonding, unbonded, producing blocks and jailed.