### PR TITLE
Update Tendermint with jailed validators  

### DIFF
--- a/x/staking/keeper/delay_updates.go
+++ b/x/staking/keeper/delay_updates.go
@@ -54,16 +54,18 @@ func (k Keeper) DKGValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate {
 // is triggered by BeginBlock,
 func (k Keeper) ValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate {
 	store := ctx.KVStore(k.storeKey)
+	updateBytes := store.Get(validatorUpdatesKey)
+	updates := []abci.ValidatorUpdate{}
+	k.cdc.UnmarshalBinaryLengthPrefixed(updateBytes, &updates)
 	if len(store.Get(computeValidatorUpdateKey)) == 0 {
 		// Check mature items in queues every block, regardless of whether return validator updates
 		// or not, in order for items to be removed as soon as possible
 		k.RemoveMatureQueueItems(ctx)
-		return []abci.ValidatorUpdate{}
+		// Away from validator changeover points we only remove jailed validators from the consensus
+		// validator set
+		return k.CheckJailedValidators(ctx)
 	}
 	store.Set(computeValidatorUpdateKey, []byte{})
-	updateBytes := store.Get(validatorUpdatesKey)
-	updates := []abci.ValidatorUpdate{}
-	k.cdc.UnmarshalBinaryLengthPrefixed(updateBytes, &updates)
 	k.ExecuteUnbonding(ctx, updates)
 	k.RemoveMatureQueueItems(ctx)
 	return updates

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -195,6 +195,18 @@ func (k Keeper) RemoveMatureQueueItems(ctx sdk.Context) {
 	}
 }
 
+// CheckJailedValidators if any of the current consensus validators have been jailed, if they have then
+// update consensus validator to remove them
+func (k Keeper) CheckJailedValidators(ctx sdk.Context) []abci.ValidatorUpdate {
+	jailed := []abci.ValidatorUpdate{}
+	for _, val := range k.GetLastValidators(ctx) {
+		if val.IsJailed() {
+			jailed = append(jailed, val.ABCIValidatorUpdateZero())
+		}
+	}
+	return jailed
+}
+
 // Validator state transitions
 
 func (k Keeper) bondedToUnbonding(ctx sdk.Context, validator types.Validator) types.Validator {


### PR DESCRIPTION
Allow sdk to pass consensus validator updates to Tendermint away from aeon boundaries to remove jailed validators from the consensus validator set.