### PR TITLE
Remove jailed vals from saved updates

### DIFF
--- a/x/genutil/gentx.go
+++ b/x/genutil/gentx.go
@@ -103,6 +103,6 @@ func DeliverGenTxs(ctx sdk.Context, cdc *codec.Codec, genTxs []json.RawMessage,
 		}
 	}
 	updates := stakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	stakingKeeper.ExecuteUnbonding(ctx, updates)
+	updates = stakingKeeper.ConsensusFromDKGUpdates(ctx, updates)
 	return updates
 }

--- a/x/genutil/types/expected_keepers.go
+++ b/x/genutil/types/expected_keepers.go
@@ -13,7 +13,7 @@ import (
 // StakingKeeper defines the expected staking keeper (noalias)
 type StakingKeeper interface {
 	ApplyAndReturnValidatorSetUpdates(sdk.Context) (updates []abci.ValidatorUpdate)
-	ExecuteUnbonding(sdk.Context, []abci.ValidatorUpdate)
+	ConsensusFromDKGUpdates(sdk.Context, []abci.ValidatorUpdate) []abci.ValidatorUpdate
 }
 
 // AccountKeeper defines the expected account keeper (noalias)

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -34,7 +34,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, accountKeeper types.AccountKeep
 
 	for _, validator := range data.Validators {
 		// At genesis set all validators to producing blocks. The excess one will be removed
-		// in the ExecuteUnbonding call below
+		// in the ConsensusFromDKGUpdates call below
 		validator.ProducingBlocks = true
 		keeper.SetValidator(ctx, validator)
 
@@ -134,7 +134,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, accountKeeper types.AccountKeep
 		}
 	} else {
 		res = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-		keeper.ExecuteUnbonding(ctx, res)
+		res = keeper.ConsensusFromDKGUpdates(ctx, res)
 	}
 
 	return res

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -32,7 +32,7 @@ func TestValidatorByPowerIndex(t *testing.T) {
 
 	// must end-block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	// verify the self-delegation exists
@@ -56,14 +56,14 @@ func TestValidatorByPowerIndex(t *testing.T) {
 	// must end-block
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	require.Equal(t, 1, len(updates))
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 
 	// slash and jail the first validator
 	consAddr0 := sdk.ConsAddress(keep.PKs[0].Address())
 	keeper.Slash(ctx, consAddr0, 0, initPower, sdk.NewDecWithPrec(5, 1))
 	keeper.Jail(ctx, consAddr0)
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 
 	validator, found = keeper.GetValidator(ctx, validatorAddr)
 	require.True(t, found)
@@ -1225,7 +1225,7 @@ func TestUnbondingWhenExcessValidators(t *testing.T) {
 
 	// apply TM updates
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(keeper.GetLastValidators(ctx)))
 
 	valTokens2 := sdk.TokensFromConsensusPower(30)
@@ -1236,7 +1236,7 @@ func TestUnbondingWhenExcessValidators(t *testing.T) {
 
 	// apply TM updates
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 2, len(keeper.GetLastValidators(ctx)))
 
 	valTokens3 := sdk.TokensFromConsensusPower(10)
@@ -1247,7 +1247,7 @@ func TestUnbondingWhenExcessValidators(t *testing.T) {
 
 	// apply TM updates
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 2, len(keeper.GetLastValidators(ctx)))
 
 	// unbond the validator-2
@@ -1259,7 +1259,7 @@ func TestUnbondingWhenExcessValidators(t *testing.T) {
 
 	// apply TM updates
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 
 	// because there are extra validators waiting to get in, the queued
 	// validator (aka. validator-1) should make it into the bonded group, thus

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -334,7 +334,7 @@ func TestUndelegateSelfDelegationBelowMinSelfDelegation(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
@@ -406,7 +406,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
@@ -480,7 +480,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
@@ -563,7 +563,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	// unbond all the remaining delegation
@@ -793,7 +793,7 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 2, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
@@ -852,7 +852,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
@@ -929,7 +929,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -262,7 +262,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 
 	// end block
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	require.Equal(t, 1, len(updates))
 
 	// read updating unbonding delegation
@@ -344,7 +344,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	require.Equal(t, sdk.TokensFromConsensusPower(10), diffTokens)
 	// apply TM updates
 	updates = keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 
 	// read updated validator
 	// power decreased by 1 again, validator is out of stake
@@ -457,7 +457,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	require.Len(t, rd.Entries, 1)
 	// apply TM updates
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	// read updated validator
 	// validator decreased to zero power, should be in unbonding period
 	validator, _ = keeper.GetValidatorByConsAddr(ctx, consAddr)

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -268,7 +268,7 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 	keeper.SetValidatorByPowerIndex(ctx, validator)
 	if apply {
 		updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-		keeper.ExecuteUnbonding(ctx, updates)
+		keeper.ConsensusFromDKGUpdates(ctx, updates)
 		validator, found := keeper.GetValidator(ctx, validator.OperatorAddress)
 		if !found {
 			panic("validator expected but not found")
@@ -277,7 +277,7 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 	}
 	cachectx, _ := ctx.CacheContext()
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(cachectx)
-	keeper.ExecuteUnbonding(cachectx, updates)
+	keeper.ConsensusFromDKGUpdates(cachectx, updates)
 	validator, found := keeper.GetValidator(cachectx, validator.OperatorAddress)
 	if !found {
 		panic("validator expected but not found")

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -35,7 +35,7 @@ func TestSetValidator(t *testing.T) {
 
 	// ensure update
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	validator, found := keeper.GetValidator(ctx, valAddr)
 	require.True(t, found)
 	require.Equal(t, 1, len(updates))
@@ -190,7 +190,7 @@ func TestSlashToZeroPowerRemoved(t *testing.T) {
 	keeper.Slash(ctx, consAddr0, 0, 100, sdk.OneDec())
 	// apply TM updates
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)
-	keeper.ExecuteUnbonding(ctx, updates)
+	updates = keeper.ConsensusFromDKGUpdates(ctx, updates)
 	// validator should be unbonding
 	validator, _ = keeper.GetValidator(ctx, addrVals[0])
 	require.Equal(t, validator.GetStatus(), sdk.Unbonding)


### PR DESCRIPTION
Tendermint panics on removing a non-existent validator when processing updates. Thus, validators which have been removed due to jailing must be removed from the saved consensus validator updates.