### PR TITLE
Add min self delegation for creating validators

### DIFF
--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -8,6 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
@@ -18,7 +19,7 @@ func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(
 		valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt(),
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation,
 	)
 
 	res, err := sh(ctx, msg)
@@ -50,7 +51,7 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	// create validator with 50% commission
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	// create second validator with 0% commission
 	commission = staking.NewCommissionRates(sdk.NewDec(0), sdk.NewDec(0), sdk.NewDec(0))
 	msg = staking.NewMsgCreateValidator(valOpAddr2, valConsPk2,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err = sh(ctx, msg)
 	require.NoError(t, err)
@@ -127,7 +128,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	// create validator with 10% commission
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(110)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(110)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -135,7 +136,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	// create second validator with 10% commission
 	commission = staking.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
 	msg = staking.NewMsgCreateValidator(valOpAddr2, valConsPk2,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 	res, err = sh(ctx, msg)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -143,7 +144,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	// create third validator with 10% commission
 	commission = staking.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
 	msg = staking.NewMsgCreateValidator(valOpAddr3, valConsPk3,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 	res, err = sh(ctx, msg)
 	require.NoError(t, err)
 	require.NotNil(t, res)

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -9,6 +9,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 func TestCalculateRewardsBasic(t *testing.T) {
@@ -18,7 +19,7 @@ func TestCalculateRewardsBasic(t *testing.T) {
 	// create validator with 50% commission
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(
-		valOpAddr1, valConsPk1, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt(),
+		valOpAddr1, valConsPk1, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation,
 	)
 
 	res, err := sh(ctx, msg)
@@ -79,7 +80,7 @@ func TestCalculateRewardsAfterSlash(t *testing.T) {
 	valPower := int64(100)
 	valTokens := sdk.TokensFromConsensusPower(valPower)
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -146,7 +147,7 @@ func TestCalculateRewardsAfterManySlashes(t *testing.T) {
 	valTokens := sdk.TokensFromConsensusPower(power)
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -223,7 +224,7 @@ func TestCalculateRewardsMultiDelegator(t *testing.T) {
 	// create validator with 50% commission
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -305,7 +306,7 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 	msg := staking.NewMsgCreateValidator(
 		valOpAddr1, valConsPk1,
 		sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
-		staking.Description{}, commission, sdk.OneInt(),
+		staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation,
 	)
 
 	res, err := sh(ctx, msg)
@@ -374,7 +375,7 @@ func TestCalculateRewardsAfterManySlashesInSameBlock(t *testing.T) {
 	valTokens := sdk.TokensFromConsensusPower(power)
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -446,7 +447,7 @@ func TestCalculateRewardsMultiDelegatorMultiSlash(t *testing.T) {
 	power := int64(100)
 	valTokens := sdk.TokensFromConsensusPower(power)
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, valTokens), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)
@@ -537,7 +538,7 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	// create validator with 50% commission
 	commission := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(valOpAddr1, valConsPk1,
-		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, sdk.OneInt())
+		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation)
 
 	res, err := sh(ctx, msg)
 	require.NoError(t, err)

--- a/x/distribution/keeper/querier_test.go
+++ b/x/distribution/keeper/querier_test.go
@@ -12,6 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 )
 
@@ -160,7 +161,8 @@ func TestQueries(t *testing.T) {
 	sh := staking.NewHandler(sk)
 	comm := staking.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	msg := staking.NewMsgCreateValidator(
-		valOpAddr1, valConsPk1, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, comm, sdk.OneInt(),
+		valOpAddr1, valConsPk1, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)), staking.Description{}, comm,
+		stakingTypes.DefaultMinSelfDelegation,
 	)
 
 	res, err := sh(ctx, msg)

--- a/x/evidence/internal/keeper/infraction_test.go
+++ b/x/evidence/internal/keeper/infraction_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/evidence/internal/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -15,7 +16,7 @@ func newTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt
 	commission := staking.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 	return staking.NewMsgCreateValidator(
 		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt),
-		staking.Description{}, commission, sdk.OneInt(),
+		staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation,
 	)
 }
 

--- a/x/gov/test_common.go
+++ b/x/gov/test_common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 )
@@ -229,7 +230,7 @@ func createValidators(t *testing.T, stakingHandler sdk.Handler, ctx sdk.Context,
 		valTokens := sdk.TokensFromConsensusPower(powerAmt[i])
 		valCreateMsg := staking.NewMsgCreateValidator(
 			addrs[i], pubkeys[i], sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
-			keep.TestDescription, keep.TestCommissionRates, sdk.OneInt(),
+			keep.TestDescription, keep.TestCommissionRates, stakingTypes.DefaultMinSelfDelegation,
 		)
 
 		res, err := stakingHandler(ctx, valCreateMsg)

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -142,7 +142,7 @@ func TestSlashingMsgs(t *testing.T) {
 	commission := staking.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 
 	createValidatorMsg := staking.NewMsgCreateValidator(
-		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description, commission, sdk.OneInt(),
+		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description, commission, types.DefaultMinSelfDelegation,
 	)
 
 	header := abci.Header{Height: mapp.LastBlockHeight() + 1}

--- a/x/slashing/internal/keeper/test_common.go
+++ b/x/slashing/internal/keeper/test_common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/cosmos/cosmos-sdk/x/slashing/internal/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 )
 
@@ -149,7 +150,7 @@ func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt
 	commission := staking.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 	return staking.NewMsgCreateValidator(
 		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt),
-		staking.Description{}, commission, sdk.OneInt(),
+		staking.Description{}, commission, stakingTypes.DefaultMinSelfDelegation,
 	)
 }
 

--- a/x/staking/alias.go
+++ b/x/staking/alias.go
@@ -96,6 +96,7 @@ var (
 	ErrSelfDelegationBelowMinimum      = types.ErrSelfDelegationBelowMinimum
 	ErrMinSelfDelegationInvalid        = types.ErrMinSelfDelegationInvalid
 	ErrMinSelfDelegationDecreased      = types.ErrMinSelfDelegationDecreased
+	ErrMinSelfDelegationInsufficient   = types.ErrMinSelfDelegationInsufficient
 	ErrEmptyDelegatorAddr              = types.ErrEmptyDelegatorAddr
 	ErrBadDenom                        = types.ErrBadDenom
 	ErrBadDelegationAddr               = types.ErrBadDelegationAddr

--- a/x/staking/app_test.go
+++ b/x/staking/app_test.go
@@ -149,7 +149,7 @@ func TestStakingMsgs(t *testing.T) {
 	// create validator
 	description := NewDescription("foo_moniker", "", "", "", "")
 	createValidatorMsg := NewMsgCreateValidator(
-		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description, commissionRates, sdk.OneInt(),
+		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description, commissionRates, types.DefaultMinSelfDelegation,
 	)
 
 	header := abci.Header{Height: mApp.LastBlockHeight() + 1}

--- a/x/staking/handler.go
+++ b/x/staking/handler.go
@@ -82,6 +82,10 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 		return nil, err
 	}
 
+	if msg.MinSelfDelegation.LT(k.MinSelfDelegation(ctx)) {
+		return nil, sdkerrors.Wrapf(ErrMinSelfDelegationInsufficient,
+			"got: %s, valid: %s", msg.MinSelfDelegation, k.MinSelfDelegation(ctx))
+	}
 	validator.MinSelfDelegation = msg.MinSelfDelegation
 
 	k.SetValidator(ctx, validator)

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -358,7 +358,7 @@ func TestEditValidatorDecreaseMinSelfDelegation(t *testing.T) {
 
 	// create validator
 	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0], initBond)
-	msgCreateValidator.MinSelfDelegation = sdk.NewInt(2)
+	msgCreateValidator.MinSelfDelegation = types.DefaultMinSelfDelegation.Mul(sdk.NewInt(2))
 	res, err := handleMsgCreateValidator(ctx, msgCreateValidator, keeper)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -391,7 +391,7 @@ func TestEditValidatorIncreaseMinSelfDelegationBeyondCurrentBond(t *testing.T) {
 
 	// create validator
 	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0], initBond)
-	msgCreateValidator.MinSelfDelegation = sdk.NewInt(2)
+	msgCreateValidator.MinSelfDelegation = types.DefaultMinSelfDelegation.Mul(sdk.NewInt(2))
 	res, err := handleMsgCreateValidator(ctx, msgCreateValidator, keeper)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1398,17 +1398,17 @@ func TestInvalidCoinDenom(t *testing.T) {
 
 	commission := types.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.ZeroDec())
 
-	msgCreate := types.NewMsgCreateValidator(valA, keep.PKs[0], invalidCoin, Description{}, commission, sdk.OneInt())
+	msgCreate := types.NewMsgCreateValidator(valA, keep.PKs[0], invalidCoin, Description{}, commission, types.DefaultMinSelfDelegation)
 	res, err := handleMsgCreateValidator(ctx, msgCreate, keeper)
 	require.Error(t, err)
 	require.Nil(t, res)
 
-	msgCreate = types.NewMsgCreateValidator(valA, keep.PKs[0], validCoin, Description{}, commission, sdk.OneInt())
+	msgCreate = types.NewMsgCreateValidator(valA, keep.PKs[0], validCoin, Description{}, commission, types.DefaultMinSelfDelegation)
 	res, err = handleMsgCreateValidator(ctx, msgCreate, keeper)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	msgCreate = types.NewMsgCreateValidator(valB, keep.PKs[1], validCoin, Description{}, commission, sdk.OneInt())
+	msgCreate = types.NewMsgCreateValidator(valB, keep.PKs[1], validCoin, Description{}, commission, types.DefaultMinSelfDelegation)
 	res, err = handleMsgCreateValidator(ctx, msgCreate, keeper)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1440,6 +1440,26 @@ func TestInvalidCoinDenom(t *testing.T) {
 
 	msgRedelegate = types.NewMsgBeginRedelegate(delAddr, valA, valB, oneCoin)
 	res, err = handleMsgBeginRedelegate(ctx, msgRedelegate, keeper)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestInvalidMinSelfDelegation(t *testing.T) {
+	ctx, _, keeper, _ := keep.CreateTestInput(t, false, 1000)
+	valA := sdk.ValAddress(keep.Addrs[0])
+
+	valTokens := sdk.TokensFromConsensusPower(100)
+	validCoin := sdk.NewCoin(sdk.DefaultBondDenom, valTokens)
+	commission := types.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.ZeroDec())
+
+	msgCreate := types.NewMsgCreateValidator(valA, keep.PKs[0], validCoin, Description{}, commission,
+		types.DefaultMinSelfDelegation.Sub(sdk.NewInt(1)))
+	res, err := handleMsgCreateValidator(ctx, msgCreate, keeper)
+	require.Error(t, err)
+	require.Nil(t, res)
+
+	msgCreate = types.NewMsgCreateValidator(valA, keep.PKs[0], validCoin, Description{}, commission, types.DefaultMinSelfDelegation)
+	res, err = handleMsgCreateValidator(ctx, msgCreate, keeper)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 }

--- a/x/staking/keeper/params.go
+++ b/x/staking/keeper/params.go
@@ -50,6 +50,12 @@ func (k Keeper) BondDenom(ctx sdk.Context) (res string) {
 	return
 }
 
+// MinSelfDelegation - minimum self delegation when creating a new validator
+func (k Keeper) MinSelfDelegation(ctx sdk.Context) (res sdk.Int) {
+	k.paramstore.Get(ctx, types.KeyMinSelfDelegation, &res)
+	return
+}
+
 // Get all parameteras as types.Params
 func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 	return types.NewParams(
@@ -58,6 +64,7 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 		k.MaxEntries(ctx),
 		k.HistoricalEntries(ctx),
 		k.BondDenom(ctx),
+		k.MinSelfDelegation(ctx),
 	)
 }
 

--- a/x/staking/simulation/genesis.go
+++ b/x/staking/simulation/genesis.go
@@ -50,7 +50,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 	// NewSimulationManager constructor for this to work
 	simState.UnbondTime = unbondTime
 
-	params := types.NewParams(simState.UnbondTime, maxValidators, 7, 3, sdk.DefaultBondDenom)
+	params := types.NewParams(simState.UnbondTime, maxValidators, 7, 3, sdk.DefaultBondDenom, types.DefaultMinSelfDelegation)
 
 	// validators & delegations
 	var (

--- a/x/staking/test_common.go
+++ b/x/staking/test_common.go
@@ -29,7 +29,7 @@ var (
 
 func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt sdk.Int) MsgCreateValidator {
 	return types.NewMsgCreateValidator(
-		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt), Description{}, commissionRates, sdk.OneInt(),
+		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt), Description{}, commissionRates, types.DefaultMinSelfDelegation,
 	)
 }
 
@@ -39,7 +39,7 @@ func NewTestMsgCreateValidatorWithCommission(address sdk.ValAddress, pubKey cryp
 	commission := NewCommissionRates(commissionRate, sdk.OneDec(), sdk.ZeroDec())
 
 	return types.NewMsgCreateValidator(
-		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt), Description{}, commission, sdk.OneInt(),
+		address, pubKey, sdk.NewCoin(sdk.DefaultBondDenom, amt), Description{}, commission, types.DefaultMinSelfDelegation,
 	)
 }
 

--- a/x/staking/types/errors.go
+++ b/x/staking/types/errors.go
@@ -56,4 +56,5 @@ var (
 	ErrNeitherShareMsgsGiven           = sdkerrors.Register(ModuleName, 43, "neither shares amount nor shares percent provided")
 	ErrInvalidHistoricalInfo           = sdkerrors.Register(ModuleName, 44, "invalid historical info")
 	ErrNoHistoricalInfo                = sdkerrors.Register(ModuleName, 45, "no historical info found")
+	ErrMinSelfDelegationInsufficient   = sdkerrors.Register(ModuleName, 46, "minimum self delegation insufficient")
 )


### PR DESCRIPTION
- Add minimum self delegation to staking parameters
- Return error if create validator message has MinSelfDelegation below the global allowed minimum set in the parameters