### PR TITLE
Add rewards for DKG/DRB

### DIFF
--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -27,7 +27,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	if ctx.BlockHeight() > 1 {
 		previousProposer := k.GetPreviousProposerConsAddr(ctx)
-		k.AllocateTokens(ctx, sumPreviousPrecommitPower, previousTotalPower, previousProposer, req.LastCommitInfo.GetVotes())
+		k.AllocateTokens(ctx, sumPreviousPrecommitPower, previousTotalPower, previousProposer, req)
 	}
 
 	// record the proposer for when we payout on the next block

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -67,6 +67,7 @@ func (k Keeper) AllocateTokens(
 			powerFraction := sdk.NewDec(val.VotingPower).QuoTruncate(sdk.NewDec(valSet.TotalVotingPower()))
 			reward := feesCollected.MulDecTruncate(beaconRewardMultiplier).MulDecTruncate(powerFraction)
 			k.AllocateTokensToValidator(ctx, validator, reward)
+			logger.Debug("Beacon reward allocated", "val", fmt.Sprintf("%X", addr), "amount", reward.String())
 			remaining = remaining.Sub(reward)
 		}
 	}

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -53,11 +53,13 @@ func (k Keeper) AllocateTokens(
 	beaconRewardMultiplier := k.GetBeaconReward(ctx)
 	vals := []*tmtypes.Validator{}
 	if len(entropy.GroupSignature) != 0 {
+		// Get all validators (including those than have been jailed)
 		k.stakingKeeper.IterateLastValidators(ctx, func(index int64, val exported.ValidatorI) bool {
 			vals = append(vals, tmtypes.NewValidator(val.GetConsPubKey(), val.GetConsensusPower()))
 			return false
 		})
 
+		// Pay beacon rewards to those in qual
 		valSet := tmtypes.NewValidatorSet(vals)
 		for _, index := range entropy.SuccessfulVals {
 			addr, val := valSet.GetByIndex(int(index))

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -103,21 +103,27 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 			SignedLastBlock: true,
 		},
 	}
-	k.AllocateTokens(ctx, 200, 200, valConsAddr2, votes)
+	req := abci.RequestBeginBlock{
+		LastCommitInfo: abci.LastCommitInfo{
+			Round: 0,
+			Votes: votes,
+		},
+	}
+	k.AllocateTokens(ctx, 200, 200, valConsAddr2, req)
 
-	// 98 outstanding rewards (100 less 2 to community pool)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(465, 1)}}, k.GetValidatorOutstandingRewards(ctx, valOpAddr1))
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(515, 1)}}, k.GetValidatorOutstandingRewards(ctx, valOpAddr2))
-	// 2 community pool coins
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(2)}}, k.GetFeePool(ctx).CommunityPool)
-	// 50% commission for first proposer, (0.5 * 93%) * 100 / 2 = 23.25
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2325, 2)}}, k.GetValidatorAccumulatedCommission(ctx, valOpAddr1))
+	// 97 outstanding rewards (100 less 3 to community pool (1 from non-distributed beacon reward))
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(460, 1)}}, k.GetValidatorOutstandingRewards(ctx, valOpAddr1))
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(510, 1)}}, k.GetValidatorOutstandingRewards(ctx, valOpAddr2))
+	// 3 community pool coins
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(3)}}, k.GetFeePool(ctx).CommunityPool)
+	// 50% commission for first proposer, (0.5 * 92%) * 100 / 2 = 23.00
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2300, 2)}}, k.GetValidatorAccumulatedCommission(ctx, valOpAddr1))
 	// zero commission for second proposer
 	require.True(t, k.GetValidatorAccumulatedCommission(ctx, valOpAddr2).IsZero())
-	// just staking.proportional for first proposer less commission = (0.5 * 93%) * 100 / 2 = 23.25
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2325, 2)}}, k.GetValidatorCurrentRewards(ctx, valOpAddr1).Rewards)
-	// proposer reward + staking.proportional for second proposer = (5 % + 0.5 * (93%)) * 100 = 51.5
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(515, 1)}}, k.GetValidatorCurrentRewards(ctx, valOpAddr2).Rewards)
+	// just staking.proportional for first proposer less commission = (0.5 * 92%) * 100 / 2 = 23.00
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2300, 2)}}, k.GetValidatorCurrentRewards(ctx, valOpAddr1).Rewards)
+	// proposer reward + staking.proportional for second proposer = (5 % + 0.5 * (92%)) * 100 = 51.0
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(510, 1)}}, k.GetValidatorCurrentRewards(ctx, valOpAddr2).Rewards)
 }
 
 func TestAllocateTokensTruncation(t *testing.T) {
@@ -197,7 +203,13 @@ func TestAllocateTokensTruncation(t *testing.T) {
 			SignedLastBlock: true,
 		},
 	}
-	k.AllocateTokens(ctx, 31, 31, valConsAddr2, votes)
+	req := abci.RequestBeginBlock{
+		LastCommitInfo: abci.LastCommitInfo{
+			Round: 0,
+			Votes: votes,
+		},
+	}
+	k.AllocateTokens(ctx, 31, 31, valConsAddr2, req)
 
 	require.True(t, k.GetValidatorOutstandingRewards(ctx, valOpAddr1).IsValid())
 	require.True(t, k.GetValidatorOutstandingRewards(ctx, valOpAddr2).IsValid())

--- a/x/distribution/keeper/params.go
+++ b/x/distribution/keeper/params.go
@@ -41,3 +41,10 @@ func (k Keeper) GetWithdrawAddrEnabled(ctx sdk.Context) (enabled bool) {
 	k.paramSpace.Get(ctx, types.ParamStoreKeyWithdrawAddrEnabled, &enabled)
 	return enabled
 }
+
+// GetBeaconReward returns the current distribution beacon reward
+// rate.
+func (k Keeper) GetBeaconReward(ctx sdk.Context) (percent sdk.Dec) {
+	k.paramSpace.Get(ctx, types.ParamStoreKeyBeaconReward, &percent)
+	return percent
+}

--- a/x/distribution/keeper/querier_test.go
+++ b/x/distribution/keeper/querier_test.go
@@ -119,6 +119,7 @@ func TestQueries(t *testing.T) {
 		BaseProposerReward:  sdk.NewDecWithPrec(2, 1),
 		BonusProposerReward: sdk.NewDecWithPrec(1, 1),
 		WithdrawAddrEnabled: true,
+		BeaconReward:        sdk.NewDecWithPrec(1, 1),
 	}
 
 	keeper.SetParams(ctx, params)


### PR DESCRIPTION
- Added parameter in x/distribution for beacon rewards
- Rewards are distributed to everyone in qual on a block by block basis when the blocks contain entropy
- If the block does not contain entropy then the amount that would have been paid out in beacon rewards to added to the community pool