### PR TITLE
Handling of dkg evidence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,4 @@ require (
 
 replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 
-replace github.com/tendermint/tendermint => github.com/fetchai/cosmos-consensus v0.12.0
+replace github.com/tendermint/tendermint => github.com/fetchai/cosmos-consensus v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqL
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fetchai/cosmos-consensus v0.12.0 h1:GHrpdYGXvNoGHAP18HQfky2532wS2kI4r3TfEegsKgk=
-github.com/fetchai/cosmos-consensus v0.12.0/go.mod h1:3uBzeHvXTweU0DE0ja1RmM/rxcf+tTajjRCfcF+DG3A=
+github.com/fetchai/cosmos-consensus v0.13.0 h1:SwAAq4qvBGuHgJbueQM+yG3Q0AIgN+bmn9bfSlQ6ums=
+github.com/fetchai/cosmos-consensus v0.13.0/go.mod h1:3uBzeHvXTweU0DE0ja1RmM/rxcf+tTajjRCfcF+DG3A=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/x/evidence/abci.go
+++ b/x/evidence/abci.go
@@ -23,7 +23,10 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 			k.HandleDoubleSign(ctx, evidence.(Equivocation))
 		case tmtypes.ABCIEvidenceTypeBeaconInactivity:
 			evidence := ConvertBeaconInactivityEvidence(tmEvidence)
-			k.HandleBeaconInactivity(ctx, evidence.(BeaconInactivity))
+			k.HandleBeaconInfraction(ctx, evidence.(BeaconInfraction))
+		case tmtypes.ABCIEvidenceTypeDKG:
+			evidence := ConvertDKGFailureEvidence(tmEvidence)
+			k.HandleBeaconInfraction(ctx, evidence.(BeaconInfraction))
 		default:
 			k.Logger(ctx).Error(fmt.Sprintf("ignored unknown evidence type: %s", tmEvidence.Type))
 		}

--- a/x/evidence/alias.go
+++ b/x/evidence/alias.go
@@ -38,6 +38,7 @@ var (
 	DefaultGenesisState             = types.DefaultGenesisState
 	ConvertDuplicateVoteEvidence    = types.ConvertDuplicateVoteEvidence
 	ConvertBeaconInactivityEvidence = types.ConvertBeaconInactivityEvidence
+	ConvertDKGFailureEvidence       = types.ConvertDKGFailureEvidence
 	KeyMaxEvidenceAge               = types.KeyMaxEvidenceAge
 	DoubleSignJailEndTime           = types.DoubleSignJailEndTime
 	ParamKeyTable                   = types.ParamKeyTable
@@ -51,5 +52,5 @@ type (
 	Handler           = types.Handler
 	Router            = types.Router
 	Equivocation      = types.Equivocation
-	BeaconInactivity  = types.BeaconInactivity
+	BeaconInfraction  = types.BeaconInfraction
 )

--- a/x/evidence/alias.go
+++ b/x/evidence/alias.go
@@ -27,21 +27,20 @@ var (
 	NewKeeper  = keeper.NewKeeper
 	NewQuerier = keeper.NewQuerier
 
-	NewMsgSubmitEvidence            = types.NewMsgSubmitEvidence
-	NewRouter                       = types.NewRouter
-	NewQueryEvidenceParams          = types.NewQueryEvidenceParams
-	NewQueryAllEvidenceParams       = types.NewQueryAllEvidenceParams
-	RegisterCodec                   = types.RegisterCodec
-	RegisterEvidenceTypeCodec       = types.RegisterEvidenceTypeCodec
-	ModuleCdc                       = types.ModuleCdc
-	NewGenesisState                 = types.NewGenesisState
-	DefaultGenesisState             = types.DefaultGenesisState
-	ConvertDuplicateVoteEvidence    = types.ConvertDuplicateVoteEvidence
-	ConvertBeaconInactivityEvidence = types.ConvertBeaconInactivityEvidence
-	ConvertDKGFailureEvidence       = types.ConvertDKGFailureEvidence
-	KeyMaxEvidenceAge               = types.KeyMaxEvidenceAge
-	DoubleSignJailEndTime           = types.DoubleSignJailEndTime
-	ParamKeyTable                   = types.ParamKeyTable
+	NewMsgSubmitEvidence         = types.NewMsgSubmitEvidence
+	NewRouter                    = types.NewRouter
+	NewQueryEvidenceParams       = types.NewQueryEvidenceParams
+	NewQueryAllEvidenceParams    = types.NewQueryAllEvidenceParams
+	RegisterCodec                = types.RegisterCodec
+	RegisterEvidenceTypeCodec    = types.RegisterEvidenceTypeCodec
+	ModuleCdc                    = types.ModuleCdc
+	NewGenesisState              = types.NewGenesisState
+	DefaultGenesisState          = types.DefaultGenesisState
+	ConvertDuplicateVoteEvidence = types.ConvertDuplicateVoteEvidence
+	ConvertBeaconEvidence        = types.ConvertBeaconEvidence
+	KeyMaxEvidenceAge            = types.KeyMaxEvidenceAge
+	DoubleSignJailEndTime        = types.DoubleSignJailEndTime
+	ParamKeyTable                = types.ParamKeyTable
 )
 
 type (

--- a/x/evidence/internal/keeper/beacon_infraction.go
+++ b/x/evidence/internal/keeper/beacon_infraction.go
@@ -72,9 +72,9 @@ func (k Keeper) HandleBeaconInfraction(ctx sdk.Context, evidence types.BeaconInf
 
 	var slashFraction sdk.Dec
 	switch evidenceType {
-	case types.TypeBeaconInactivity:
+	case tmtypes.ABCIEvidenceTypeBeaconInactivity:
 		slashFraction = k.slashingKeeper.SlashFractionBeaconInactivity(ctx)
-	case types.TypeDKGFailure:
+	case tmtypes.ABCIEvidenceTypeDKG:
 		slashFraction = k.slashingKeeper.SlashFractionDoubleSign(ctx)
 	default:
 		panic(fmt.Sprintf("Unknown beacon evidence type %s", evidenceType))

--- a/x/evidence/internal/types/codec.go
+++ b/x/evidence/internal/types/codec.go
@@ -15,7 +15,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*exported.Evidence)(nil), nil)
 	cdc.RegisterConcrete(MsgSubmitEvidence{}, "cosmos-sdk/MsgSubmitEvidence", nil)
 	cdc.RegisterConcrete(Equivocation{}, "cosmos-sdk/Equivocation", nil)
-	cdc.RegisterConcrete(BeaconInactivity{}, "cosmos-sdk/BeaconInactivity", nil)
+	cdc.RegisterConcrete(BeaconInfraction{}, "cosmos-sdk/BeaconInfraction", nil)
 }
 
 // RegisterEvidenceTypeCodec registers an external concrete Evidence type defined

--- a/x/evidence/internal/types/evidence.go
+++ b/x/evidence/internal/types/evidence.go
@@ -15,10 +15,8 @@ import (
 
 // Evidence type constants
 const (
-	RouteEquivocation    = "equivocation"
-	TypeEquivocation     = "equivocation"
-	TypeBeaconInactivity = "beacon_inactivity"
-	TypeDKGFailure       = "dkg_failure"
+	RouteEquivocation = "equivocation"
+	TypeEquivocation  = "equivocation"
 )
 
 var _ exported.Evidence = (*Equivocation)(nil)
@@ -181,24 +179,11 @@ func (e BeaconInfraction) GetValidatorPower() int64 {
 // GetTotalPower is a no-op for the BeaconInfraction type.
 func (e BeaconInfraction) GetTotalPower() int64 { return 0 }
 
-// ConvertBeaconInactivityEvidence converts a Tendermint concrete Evidence type to
-// SDK Evidence using BeaconInfraction as the concrete type.
-func ConvertBeaconInactivityEvidence(ev abci.Evidence) exported.Evidence {
+// ConvertBeaconEvidence converts a Tendermint concrete Evidence type to
+// SDK Evidence using BeaconEvidence as the concrete type.
+func ConvertBeaconEvidence(ev abci.Evidence, tmEvidenceType string) exported.Evidence {
 	return BeaconInfraction{
-		EvidenceType:     TypeBeaconInactivity,
-		Height:           ev.Height,
-		Power:            ev.Validator.Power,
-		ConsensusAddress: sdk.ConsAddress(ev.Validator.Address),
-		Time:             ev.Time,
-		Threshold:        ev.Threshold,
-	}
-}
-
-// ConvertDKGFailureEvidence converts a Tendermint concrete Evidence type to
-// SDK Evidence using BeaconInfraction as the concrete type.
-func ConvertDKGFailureEvidence(ev abci.Evidence) exported.Evidence {
-	return BeaconInfraction{
-		EvidenceType:     TypeDKGFailure,
+		EvidenceType:     tmEvidenceType,
 		Height:           ev.Height,
 		Power:            ev.Validator.Power,
 		ConsensusAddress: sdk.ConsAddress(ev.Validator.Address),

--- a/x/slashing/internal/keeper/params.go
+++ b/x/slashing/internal/keeper/params.go
@@ -42,6 +42,12 @@ func (k Keeper) SlashFractionBeaconInactivity(ctx sdk.Context) (res sdk.Dec) {
 	return
 }
 
+// SlashBeaconInactivity - fraction of power slashed in case of beacon inactivity
+func (k Keeper) SlashFractioDKGFailure(ctx sdk.Context) (res sdk.Dec) {
+	k.paramspace.Get(ctx, types.KeySlashFractionDKGFailure, &res)
+	return
+}
+
 // SlashFractionDowntime - fraction of power slashed for downtime
 func (k Keeper) SlashFractionDowntime(ctx sdk.Context) (res sdk.Dec) {
 	k.paramspace.Get(ctx, types.KeySlashFractionDowntime, &res)

--- a/x/slashing/simulation/genesis.go
+++ b/x/slashing/simulation/genesis.go
@@ -23,6 +23,7 @@ const (
 	SlashFractionDoubleSign       = "slash_fraction_double_sign"
 	SlashFractionDowntime         = "slash_fraction_downtime"
 	SlashFractionBeaconInactivity = "slash_fraction_beacon_inactivity"
+	SlashFractionDKGFailure       = "slash_fraction_dkg_failure"
 )
 
 // GenSignedBlocksWindow randomized SignedBlocksWindow
@@ -93,9 +94,16 @@ func RandomizedGenState(simState *module.SimulationState) {
 		func(r *rand.Rand) { slashFractionBeaconInactivity = GenSlashFractionDowntime(r) },
 	)
 
+	var slashFractionDKGFailure sdk.Dec
+	simState.AppParams.GetOrGenerate(
+		simState.Cdc, SlashFractionDKGFailure, &slashFractionDKGFailure, simState.Rand,
+		func(r *rand.Rand) { slashFractionDKGFailure = GenSlashFractionDowntime(r) },
+	)
+
 	params := types.NewParams(
 		signedBlocksWindow, minSignedPerWindow, downtimeJailDuration,
 		slashFractionDoubleSign, slashFractionDowntime, slashFractionBeaconInactivity,
+		slashFractionDKGFailure,
 	)
 
 	slashingGenesis := types.NewGenesisState(params, nil, nil)


### PR DESCRIPTION
- Refactored beacon related evidence so that handling of dkg and drb evidence that uses thresholds for triggering slashing is done in the same function. 
- Added slashing parameter for contributions to dkg failures