### PR TITLE
fix: slashing defaults values for beacon inactivity and dkg failures

### DIFF
--- a/x/evidence/internal/keeper/beacon_infraction.go
+++ b/x/evidence/internal/keeper/beacon_infraction.go
@@ -75,7 +75,7 @@ func (k Keeper) HandleBeaconInfraction(ctx sdk.Context, evidence types.BeaconInf
 	case tmtypes.ABCIEvidenceTypeBeaconInactivity:
 		slashFraction = k.slashingKeeper.SlashFractionBeaconInactivity(ctx)
 	case tmtypes.ABCIEvidenceTypeDKG:
-		slashFraction = k.slashingKeeper.SlashFractionDoubleSign(ctx)
+		slashFraction = k.slashingKeeper.SlashFractionDKGFailure(ctx)
 	default:
 		panic(fmt.Sprintf("Unknown beacon evidence type %s", evidenceType))
 	}

--- a/x/evidence/internal/types/expected_keepers.go
+++ b/x/evidence/internal/types/expected_keepers.go
@@ -26,6 +26,7 @@ type (
 		Slash(sdk.Context, sdk.ConsAddress, sdk.Dec, int64, int64)
 		SlashFractionDoubleSign(sdk.Context) sdk.Dec
 		SlashFractionBeaconInactivity(sdk.Context) sdk.Dec
+		SlashFractionDKGFailure(sdk.Context) sdk.Dec
 		Jail(sdk.Context, sdk.ConsAddress)
 		JailUntil(sdk.Context, sdk.ConsAddress, time.Time)
 	}

--- a/x/slashing/internal/keeper/params.go
+++ b/x/slashing/internal/keeper/params.go
@@ -42,8 +42,8 @@ func (k Keeper) SlashFractionBeaconInactivity(ctx sdk.Context) (res sdk.Dec) {
 	return
 }
 
-// SlashBeaconInactivity - fraction of power slashed in case of beacon inactivity
-func (k Keeper) SlashFractioDKGFailure(ctx sdk.Context) (res sdk.Dec) {
+// SlashFractionDKGFailure - fraction of power slashed in case of DKG failure
+func (k Keeper) SlashFractionDKGFailure(ctx sdk.Context) (res sdk.Dec) {
 	k.paramspace.Get(ctx, types.KeySlashFractionDKGFailure, &res)
 	return
 }

--- a/x/slashing/internal/types/params.go
+++ b/x/slashing/internal/types/params.go
@@ -19,8 +19,8 @@ var (
 	DefaultMinSignedPerWindow            = sdk.NewDecWithPrec(5, 1)
 	DefaultSlashFractionDoubleSign       = sdk.NewDec(1).Quo(sdk.NewDec(20))
 	DefaultSlashFractionDowntime         = sdk.NewDec(1).Quo(sdk.NewDec(100))
-	DefaultSlashFractionBeaconInactivity = sdk.NewDec(1).Quo(sdk.NewDec(100))
-	DefaultSlashFractionDKGFailure       = sdk.NewDec(1).Quo(sdk.NewDec(100))
+	DefaultSlashFractionBeaconInactivity = sdk.NewDec(0)
+	DefaultSlashFractionDKGFailure       = sdk.NewDec(0)
 )
 
 // Parameter store keys


### PR DESCRIPTION
- fix the DKG failure slashing amount which is currently set to the double sign amount. 
- set the default slashing amount for beacon inactivity (`slash_fraction_beacon_inactivty`) and dkg failures (`slash_fraction_dkg_failure`) to zero.


```
go run ./cmd/fetchd/... --home ./tmpgen/ init foo 2>&1 | jq '.app_message.slashing.params'{
  "downtime_jail_duration": "600000000000",
  "min_signed_per_window": "0.500000000000000000",
  "signed_blocks_window": "100",
  "slash_fraction_beacon_inactivty": "0.000000000000000000",
  "slash_fraction_dkg_failure": "0.000000000000000000",
  "slash_fraction_double_sign": "0.050000000000000000",
  "slash_fraction_downtime": "0.010000000000000000"
}
```

