### PR TITLE
fix: file keyring backend key recover error

### DIFF
--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -83,12 +83,11 @@ the flag --nosort is set.
 }
 
 func runAddCmdPrepare(cmd *cobra.Command, args []string) error {
-	buf := bufio.NewReader(cmd.InOrStdin())
 	clientCtx, err := client.GetClientQueryContext(cmd)
 	if err != nil {
 		return err
 	}
-
+	buf := bufio.NewReader(clientCtx.Input)
 	return RunAddCmd(clientCtx, cmd, args, buf)
 }
 

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -87,6 +87,7 @@ func runAddCmdPrepare(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	buf := bufio.NewReader(clientCtx.Input)
 	return RunAddCmd(clientCtx, cmd, args, buf)
 }

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	bip39 "github.com/cosmos/go-bip39"
 )
 
 func Test_runAddCmdBasic(t *testing.T) {
@@ -113,4 +115,48 @@ func Test_runAddCmdBasic(t *testing.T) {
 	// passwords don't match and fail interactive key generation
 	mockIn.Reset("\n" + password + "\n" + "fail" + "\n")
 	require.Error(t, cmd.ExecuteContext(ctx))
+}
+
+func TestAddRecoverFileBackend(t *testing.T) {
+	cmd := AddKeyCommand()
+	cmd.Flags().AddFlagSet(Commands("home").PersistentFlags())
+
+	mockIn := testutil.ApplyMockIODiscardOutErr(cmd)
+	kbHome := t.TempDir()
+
+	clientCtx := client.Context{}.WithKeyringDir(kbHome).WithInput(bufio.NewReader(mockIn))
+	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
+
+	cmd.SetArgs([]string{
+		"keyname1",
+		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
+		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendFile),
+		fmt.Sprintf("--%s", flagRecover),
+	})
+
+	keyringPassword := "12345678"
+
+	entropySeed, err := bip39.NewEntropy(mnemonicEntropySize)
+	require.NoError(t, err)
+
+	mnemonic, err := bip39.NewMnemonic(entropySeed)
+	require.NoError(t, err)
+
+	mockIn.Reset(fmt.Sprintf("%s\n%s\n%s\n", mnemonic, keyringPassword, keyringPassword))
+	require.NoError(t, cmd.ExecuteContext(ctx))
+
+	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendFile, kbHome, mockIn)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		mockIn.Reset(fmt.Sprintf("%s\n%s\n", keyringPassword, keyringPassword))
+		_ = kb.Delete("keyname1")
+	})
+
+	mockIn.Reset(fmt.Sprintf("%s\n%s\n", keyringPassword, keyringPassword))
+	info, err := kb.Key("keyname1")
+	require.NoError(t, err)
+	require.Equal(t, "keyname1", info.GetName())
 }

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -29,7 +29,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)
 	require.NoError(t, err)
 
-	clientCtx := client.Context{}.WithKeyringDir(kbHome)
+	clientCtx := client.Context{}.WithKeyringDir(kbHome).WithInput(mockIn)
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
 	t.Cleanup(func() {

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -1,11 +1,12 @@
 package simapp
 
 import (
-	airdroptypes "github.com/cosmos/cosmos-sdk/x/airdrop/types"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	airdroptypes "github.com/cosmos/cosmos-sdk/x/airdrop/types"
 
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"

--- a/x/airdrop/client/cli/tx.go
+++ b/x/airdrop/client/cli/tx.go
@@ -65,7 +65,7 @@ Example:
 				return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%s is not a valid drip rate", args[2])
 			}
 
-			msg := types.NewMsgAirDrop(clientCtx.GetFromAddress(), coin, dripAmount)
+			msg := types.NewMsgAirDrop(clientCtx.GetFromAddress().String(), coin, dripAmount)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/airdrop/keeper/genesis_test.go
+++ b/x/airdrop/keeper/genesis_test.go
@@ -11,10 +11,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
-var (
-	addr = sdk.AccAddress([]byte("addr________________"))
-)
-
 type GenesisTestSuite struct {
 	suite.Suite
 

--- a/x/airdrop/keeper/keeper_test.go
+++ b/x/airdrop/keeper/keeper_test.go
@@ -40,7 +40,6 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.app.AirdropKeeper.SetParams(s.ctx, types.NewParams(addr1.String(), addr2.String(), addr3.String(), addr4.String()))
 }
 
-
 func (s *KeeperTestSuite) TestAddNewFund() {
 	amount := sdk.NewInt64Coin(sdk.DefaultBondDenom, 4000)
 	s.Require().NoError(s.app.BankKeeper.SetBalance(s.ctx, addr1, amount)) // ensure the account is funded
@@ -232,8 +231,8 @@ func (s *KeeperTestSuite) TestMultiDenomFeeDrip() {
 	s.Require().Equal(feeCollectorBalanceStake, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(0)))
 	s.Require().Equal(feeCollectorBalanceDenom, sdk.NewCoin("denom", sdk.NewInt(0)))
 
-	_, err := s.app.AirdropKeeper.DripAllFunds(s.ctx)	// test case - drip the funds
-	s.Require().NoError(err) 							// check that the fees have been transferred
+	_, err := s.app.AirdropKeeper.DripAllFunds(s.ctx) // test case - drip the funds
+	s.Require().NoError(err)                          // check that the fees have been transferred
 
 	moduleBalanceStake = s.app.BankKeeper.GetBalance(s.ctx, moduleAddress, sdk.DefaultBondDenom)
 	moduleBalanceDenom = s.app.BankKeeper.GetBalance(s.ctx, moduleAddress, "denom")
@@ -241,9 +240,9 @@ func (s *KeeperTestSuite) TestMultiDenomFeeDrip() {
 	feeCollectorBalanceDenom = s.app.BankKeeper.GetBalance(s.ctx, feeCollectorAddress, "denom")
 
 	s.Require().Equal(feeCollectorBalanceStake, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1300))) // 800 drip fund 1, 500 drip fund 2
-	s.Require().Equal(feeCollectorBalanceDenom, sdk.NewCoin("denom", sdk.NewInt(400))) 		// 100 drip fund 3, 300 drip fund 4
-	s.Require().Equal(moduleBalanceStake, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(700))) 		// remainder 500 from fund 1, remainder 200 from fund 2
-	s.Require().Equal(moduleBalanceDenom, sdk.NewCoin("denom", sdk.NewInt(1600)))       		// remainder 900 from fund 3, remainder 700 from fund 4
+	s.Require().Equal(feeCollectorBalanceDenom, sdk.NewCoin("denom", sdk.NewInt(400)))               // 100 drip fund 3, 300 drip fund 4
+	s.Require().Equal(moduleBalanceStake, sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(700)))        // remainder 500 from fund 1, remainder 200 from fund 2
+	s.Require().Equal(moduleBalanceDenom, sdk.NewCoin("denom", sdk.NewInt(1600)))                    // remainder 900 from fund 3, remainder 700 from fund 4
 
 }
 

--- a/x/airdrop/module.go
+++ b/x/airdrop/module.go
@@ -25,7 +25,7 @@ var (
 	_ module.AppModuleBasic = AppModuleBasic{}
 )
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleBasic defines the basic application module used by the airdrop module.
 type AppModuleBasic struct{}

--- a/x/airdrop/types/airdrop_test.go
+++ b/x/airdrop/types/airdrop_test.go
@@ -4,13 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	addr = sdk.AccAddress([]byte("addr________________"))
-	addrInvalid = sdk.AccAddress([]byte(""))
 )
 
 func TestFundValidateBasic(t *testing.T) {
@@ -49,8 +45,10 @@ func TestFundDrip(t *testing.T) {
 	require.Equal(t, fundHighDrip.Amount.Amount.Int64(), int64(0))
 }
 
-func TestMsgAirdropValidateBasic (t *testing.T) {
+func TestMsgAirdropValidateBasic(t *testing.T) {
+	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	addrInvalid := sdk.AccAddress([]byte("\n\n\n\n\taddr________________\t\n\n\n\n\n"))
 	amount := sdk.NewInt64Coin("test", 100)
-	require.NoError(t, NewMsgAirDrop(addr, amount, sdk.NewInt(20)).ValidateBasic())
-	require.Error(t, NewMsgAirDrop(addrInvalid, amount, sdk.NewInt(20)).ValidateBasic())
+	require.NoError(t, NewMsgAirDrop(addr.String(), amount, sdk.NewInt(20)).ValidateBasic())
+	require.Error(t, NewMsgAirDrop(addrInvalid.String(), amount, sdk.NewInt(20)).ValidateBasic())
 }

--- a/x/airdrop/types/genesis_test.go
+++ b/x/airdrop/types/genesis_test.go
@@ -3,22 +3,19 @@ package types_test
 import (
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/x/airdrop/types"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
-	addr        = sdk.AccAddress([]byte("addr________________"))
-	invalidAddr = sdk.AccAddress([]byte("\n\n\n\n\taddr________________\t\n\n\n\n\n"))
-)
-
 func TestNewGenesisState(t *testing.T) {
 	p := types.NewParams()
+
 	expectedFunds := []types.ActiveFund{
 		{
-			Sender: addr.String(),
+			Sender: sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String(),
 			Fund: &types.Fund{
 				Amount:     &sdk.Coin{Denom: "test", Amount: sdk.NewInt(10)},
 				DripAmount: sdk.NewInt(1),
@@ -34,6 +31,7 @@ func TestNewGenesisState(t *testing.T) {
 }
 
 func TestValidateGenesisState(t *testing.T) {
+	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 	p1 := types.Params{
 		AllowList: []string{
 			addr.String(), // valid address
@@ -41,7 +39,7 @@ func TestValidateGenesisState(t *testing.T) {
 	}
 	p2 := types.Params{
 		AllowList: []string{
-			invalidAddr.String(), // invalid address
+			sdk.AccAddress([]byte("\n\n\n\n\taddr________________\t\n\n\n\n\n")).String(), // invalid address
 		},
 	}
 	funds := []types.ActiveFund{

--- a/x/airdrop/types/msgs.go
+++ b/x/airdrop/types/msgs.go
@@ -9,8 +9,8 @@ const (
 	TypeMsgAirDrop = "airdrop"
 )
 
-func NewMsgAirDrop(fromAddr sdk.AccAddress, amount sdk.Coin, dripAmount sdk.Int) *MsgAirDrop {
-	return &MsgAirDrop{FromAddress: fromAddr.String(), Fund: &Fund{
+func NewMsgAirDrop(fromAddr string, amount sdk.Coin, dripAmount sdk.Int) *MsgAirDrop {
+	return &MsgAirDrop{FromAddress: fromAddr, Fund: &Fund{
 		Amount:     &amount,
 		DripAmount: dripAmount,
 	}}

--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -55,7 +55,7 @@ func (b Balance) Validate() error {
 	}
 
 	// sort the coins post validation
-	b.Coins = b.Coins.Sort()
+	b.Coins.Sort()
 
 	return nil
 }


### PR DESCRIPTION
key recover fails with EOF errors when attempting to read keyring
password from piped file.

This change allows to recover the current `*bufio.Reader` from the context
instead of creating a new one, in order to have the mnemonic and
password read from the same source.

In still require the application to init the context with a
`*bufio.Reader` argument to `WithInput(r io.Reader)`.