### PR TITLE
fix: keys import/export need also to read from the proper reader 

### DIFF
--- a/client/keys/export.go
+++ b/client/keys/export.go
@@ -31,11 +31,11 @@ FULLY AWARE OF THE RISKS. If you are unsure, you may want to do some research
 and export your keys in ASCII-armored encrypted format.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			buf := bufio.NewReader(cmd.InOrStdin())
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
+			buf := bufio.NewReader(clientCtx.Input)
 			unarmored, _ := cmd.Flags().GetBool(flagUnarmoredHex)
 			unsafe, _ := cmd.Flags().GetBool(flagUnsafe)
 

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -18,11 +18,11 @@ func ImportKeyCommand() *cobra.Command {
 		Long:  "Import a ASCII armored private key into the local keybase.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			buf := bufio.NewReader(cmd.InOrStdin())
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
+			buf := bufio.NewReader(clientCtx.Input)
 
 			bz, err := ioutil.ReadFile(args[1])
 			if err != nil {

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -23,11 +24,12 @@ func Test_runImportCmd(t *testing.T) {
 
 	// Now add a temporary keybase
 	kbHome := t.TempDir()
-	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)
+	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, nil)
 
 	clientCtx := client.Context{}.
 		WithKeyringDir(kbHome).
-		WithKeyring(kb)
+		WithKeyring(kb).
+		WithInput(bufio.NewReader(mockIn))
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
 	require.NoError(t, err)

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -45,8 +45,8 @@ func ApplyMockIODiscardOutErr(c *cobra.Command) BufferReader {
 	mockIn := strings.NewReader("")
 
 	c.SetIn(mockIn)
-	c.SetOut(os.Stdout)
-	c.SetErr(os.Stdout)
+	c.SetOut(ioutil.Discard)
+	c.SetErr(ioutil.Discard)
 
 	return mockIn
 }

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -45,8 +45,8 @@ func ApplyMockIODiscardOutErr(c *cobra.Command) BufferReader {
 	mockIn := strings.NewReader("")
 
 	c.SetIn(mockIn)
-	c.SetOut(ioutil.Discard)
-	c.SetErr(ioutil.Discard)
+	c.SetOut(os.Stdout)
+	c.SetErr(os.Stdout)
 
 	return mockIn
 }


### PR DESCRIPTION
continuation from #106 on other impacted commands:
- keys import
- keys export