### PR TITLE
fix: correct issue where gas simulation can't be made with --generate-only flag

### DIFF
--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -45,7 +45,6 @@ func GenerateOrBroadcastTxWithFactory(clientCtx client.Context, txf Factory, msg
 // simulated and also printed to the same writer before the transaction is
 // printed.
 func GenerateTx(clientCtx client.Context, txf Factory, msgs ...sdk.Msg) error {
-	var updatedTxf Factory
 	if txf.SimulateAndExecute() {
 		if clientCtx.Offline {
 			return errors.New("cannot estimate gas in offline mode")
@@ -53,7 +52,8 @@ func GenerateTx(clientCtx client.Context, txf Factory, msgs ...sdk.Msg) error {
 
 		// If we are simulating the transaction, we are not in offline mode. Then we need to lookup correct sequence
 		// number and account number information. Otherwise it will fail
-		txf, err := PrepareFactory(clientCtx, txf)
+		var err error
+		txf, err = PrepareFactory(clientCtx, txf)
 		if err != nil {
 			return err
 		}
@@ -63,12 +63,10 @@ func GenerateTx(clientCtx client.Context, txf Factory, msgs ...sdk.Msg) error {
 			return err
 		}
 
-		updatedTxf = txf.WithGas(adjusted)
-	} else {
-		updatedTxf = txf
+		txf = txf.WithGas(adjusted)
 	}
 
-	tx, err := BuildUnsignedTx(updatedTxf, msgs...)
+	tx, err := BuildUnsignedTx(txf, msgs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Updated SDK logic to correctly query the account number and sequence when simulating transactions using the `--generate-only` flag